### PR TITLE
chore(stack): atualizar bibliotecas e corrigir configuração do MLflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Após alterar a configuração, saia do container (exit); **rode novamente** o c
 - Clique no botão **'Register Model'** e escolha a opção **'Create New Model'**;
 - Dê o nome **CLF_CYBER_BULLYING_TWEETS** para o modelo e clique em **'Register'**;
 - Na barra lateral esquerda clique em **'Models'**;
-- Clique no link para a última versão do modelo que está em **'Latest Version'**;
+- Clique no link do modelo registrado **CLF_CYBER_BULLYING_TWEETS** que está em **'Registered Models'**;
 - Na opção **'Aliases'**, clique em **'Add'**;
 - Digite **_production_** e clique em **'Save aliases'**.
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,14 +2,14 @@
 FROM python:3.12
 
 # Alterar sempre que houver mudança de versões da Stack e/ou da mllibprodest
-ENV STACK_VERSION="r1.6.16 (mllibprodest==1.8.10)"
+ENV STACK_VERSION="r1.6.17 (mllibprodest==1.8.11)"
 
 WORKDIR /data
 COPY *.py *.sh .
 
 RUN useradd -m apiuser && chmod -R u=rx,g=rx,o=rx /data
-RUN pip install --no-cache-dir --upgrade pip setuptools && pip install --no-cache-dir pymongo==4.15.2 requests==2.32.5 \
-    numpy==2.3.3 pika==1.3.2 uvicorn==0.37.0 fastapi==0.118.0 pydantic==2.11.9
+RUN pip install --no-cache-dir --upgrade pip setuptools && pip install --no-cache-dir pymongo==4.15.4 requests==2.32.5 \
+    numpy==2.3.5 pika==1.3.2 uvicorn==0.38.0 fastapi==0.121.2 pydantic==2.12.4
 
 USER apiuser
 ENTRYPOINT ["/bin/bash", "init_app.sh"]

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ fi
 base_path=$(pwd)
 repo=https://github.com/prodest/modelo-teste.git
 docker_composer_name=docker-compose-linux-x86_64
-url_docker_compose=https://github.com/docker/compose/releases/download/v2.39.4/$docker_composer_name
+url_docker_compose=https://github.com/docker/compose/releases/download/v2.40.3/$docker_composer_name
 
 if [ ! -f "$base_path/stack/docker-compose" ]; then
     echo -e ">>> Baixando o Docker Compose...\n"

--- a/model_registry/Dockerfile
+++ b/model_registry/Dockerfile
@@ -8,8 +8,8 @@ ENV PY_INST_DIR=/usr/local/lib/python3.12/site-packages
 WORKDIR /tmp
 COPY modify_conf_mlflow.sh make_signup.py mlflow_cred.txt .
 
-RUN pip install --no-cache-dir --upgrade pip setuptools && pip install --no-cache-dir mlflow[auth]==3.4.0 boto3==1.40.43 \
-    numpy==2.3.3 && /tmp/modify_conf_mlflow.sh && rm /tmp/modify_conf_mlflow.sh
+RUN pip install --no-cache-dir --upgrade pip setuptools && pip install --no-cache-dir mlflow[auth]==3.6.0 boto3==1.40.75 \
+    numpy==2.3.5 && /tmp/modify_conf_mlflow.sh && rm /tmp/modify_conf_mlflow.sh
 
 WORKDIR /usr/local/bin
 COPY mlflow_init.sh .

--- a/model_registry/mlflow_init.sh
+++ b/model_registry/mlflow_init.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
+export MLFLOW_SERVER_ALLOWED_HOSTS="${MLFLOW_SERVER_ALLOWED_HOSTS:-localhost,127.0.0.1}"
+
 mlflow db upgrade sqlite:///mlflow.db
-mlflow server --app-name basic-auth --backend-store-uri sqlite:///mlflow.db --host 0.0.0.0 --default-artifact-root $DEFAULT_ARTIFACT_ROOT
+
+mlflow server \
+  --app-name basic-auth \
+  --backend-store-uri sqlite:///mlflow.db \
+  --host 0.0.0.0 \
+  --allowed-hosts "$MLFLOW_SERVER_ALLOWED_HOSTS" \
+  --default-artifact-root "$DEFAULT_ARTIFACT_ROOT"

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -15,7 +15,7 @@ x-common-variables: &common-variables
 services:
   database:
     # https://hub.docker.com/_/mongo
-    image: mongo:8.0.14-noble
+    image: mongo:8.2.1-noble
     environment:
       <<: *stack-common-env
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
@@ -43,7 +43,7 @@ services:
 
   queue:
     # https://hub.docker.com/_/rabbitmq
-    image: rabbitmq:4.1.4-management-alpine
+    image: rabbitmq:4.2.1-management-alpine
     environment:
       <<: *stack-common-env
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
@@ -143,6 +143,7 @@ services:
       # troque mlflow pelo nome do bucket que desejar
       DEFAULT_ARTIFACT_ROOT: s3://mlflow/artefatos
       MLFLOW_FLASK_SERVER_SECRET_KEY: ${MLFLOW_FLASK_SERVER_SECRET_KEY}
+      MLFLOW_SERVER_ALLOWED_HOSTS: ${MLFLOW_SERVER_ALLOWED_HOSTS:-localhost,127.0.0.1,*}
     volumes:
       - ../model_registry/mlflow_data:/mlflow_data
     ports:

--- a/temp_builder/Dockerfile
+++ b/temp_builder/Dockerfile
@@ -6,6 +6,6 @@
 FROM python:3.12
 
 WORKDIR prodest-ml-stack
-RUN pip install --no-cache-dir --upgrade pip setuptools && pip install --no-cache-dir numpy "python-jose[cryptography]==3.5.0" "passlib[sha256_crypt]==1.7.4"
+RUN pip install --no-cache-dir --upgrade pip setuptools && pip install --no-cache-dir numpy==2.3.5 "python-jose[cryptography]==3.5.0" "passlib[sha256_crypt]==1.7.4"
 
 CMD ["/bin/bash", "temp_builder/modify_credentials_dockerfiles.sh"]


### PR DESCRIPTION
Atualizadas as bibliotecas de toda a stack.

Durante o upgrade para MLflow 3.6, o novo security middleware passou a validar o cabeçalho Host, causando o erro:

"Invalid Host header - possible DNS rebinding attack detected"

Para corrigir, foram aplicados os seguintes ajustes:

- Adicionado export MLFLOW_SERVER_ALLOWED_HOSTS no mlflow_init.sh com os valores padrão (localhost,127.0.0.1)
- Incluído --allowed-hosts "$MLFLOW_SERVER_ALLOWED_HOSTS" na inicialização do servidor MLflow
- Ajustado o docker-compose.yml para definir MLFLOW_SERVER_ALLOWED_HOSTS com fallback localhost,127.0.0.1,*

Essas alterações garantem compatibilidade com o middleware de segurança do MLflow 3.6 e permitem acesso normal via Docker/WSL2.